### PR TITLE
Allow aarch64 run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         arch:
            - arm-linux-musleabihf
-           #- aarch64-linux-musl
+           - aarch64-linux-musl
     
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/33262b98-b364-4011-8b9d-b85988e7fecc)

The aarch64 looks a lot more working than the arm on a CM4 which is neat!

Just trying to see if I can actually use this to flash the ioboard on the CM4...... AND IT DOES!

![image](https://github.com/user-attachments/assets/b9fa6f8b-93d8-4d96-b7da-bd9fe6b85545)

Only thing that needs to be updated is that we need the GPIO pins to be offset to align with CM4 builds.
ie. Need to add 512 to the current GPIO pins used in usercfg.txt and ioreset 

Noted that in https://github.com/CoolITSystemsInc/cdu-utils/issues/85 and https://github.com/CoolITSystemsInc/CDU-Products/issues/24