### PR TITLE
BUILD - Adjust output artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,6 @@ jobs:
     - name: Upload stm32flash binary
       uses: actions/upload-artifact@v4
       with:
-        name: stm32flash${{ matrix.arch == 'aarch64-linux-musl' && '-64' || '' }}
+        name: stm32flash-${{ matrix.arch }}
         path: ./stm32flash
 


### PR DESCRIPTION
Pretty much the same as https://github.com/CoolITSystemsInc/libmodbus/pull/8

This does not effect our build system in the slightest until we make the next release here and attach this artifact to the release

On release, in all repos that use "name: Download stm32flash library from release" we will need to change:

fileName: "stm32flash.zip"

to

fileName: "stm32flash-${{ matrix.arch }}.zip"

Repos that will need the change:

- cdu-build https://github.com/CoolITSystemsInc/cdu-build/blob/61dee87c25065ffedaf35ab645a4bf19804f737e/.github/workflows/main.yaml#L145